### PR TITLE
Fix PHP Deprecated errors: Creation of dynamic property

### DIFF
--- a/tests/condition_test.php
+++ b/tests/condition_test.php
@@ -34,6 +34,19 @@ use availability_badge\condition;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class availability_badge_condition_testcase extends advanced_testcase {
+
+    /** @var \stdClass course record. */
+    private $course;
+
+    /** @var \stdClass The details of the test activity module. */
+    private $module;
+
+    /** @var int ID of badge. */
+    private $badgeid;
+
+    /** @var \stdClass a test user. */
+    private $user;
+
     /**
      * Load required classes.
      */


### PR DESCRIPTION
Hi @tlock,

Thanks for the plugin. It is very useful feature for the badges.

We are getting the following PHP deprecated errors when we run the PHPUnit test, as with PHP8.2 and later PHP versions, they don't support dynamic property creation. Could you please review the fix and check if this looks ok? 

PHP Deprecated:  Creation of dynamic property availability_badge_condition_testcase::$course is deprecated in C:\Users\as38293\workspace\ou-moodle2\availability\condition\badge\tests\condition_test.php on line 61
PHP Deprecated:  Creation of dynamic property availability_badge_condition_testcase::$user is deprecated in C:\Users\as38293\workspace\ou-moodle2\availability\condition\badge\tests\condition_test.php on line 62
PHP Deprecated:  Creation of dynamic property availability_badge_condition_testcase::$badgeid is deprecated in C:\Users\as38293\workspace\ou-moodle2\availability\condition\badge\tests\condition_test.php on line 88
PHP Deprecated:  Creation of dynamic property availability_badge_condition_testcase::$module is deprecated in C:\Users\as38293\workspace\ou-moodle2\availability\condition\badge\tests\condition_test.php on line 98

Thanks,
Anupama
